### PR TITLE
TOC at fixed position

### DIFF
--- a/main/static/bootstrap/bootstrap.css
+++ b/main/static/bootstrap/bootstrap.css
@@ -2370,3 +2370,12 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
     text-align: right;
     padding-bottom: 10px;
 }
+
+/* got the TOC to display on the right
+   side of the google_doc page */
+div#nav-wrap {
+	position: fixed;
+	top: 40px;
+	margin-left: 710px;
+	width: 220px;
+}

--- a/main/templates/google_doc.html
+++ b/main/templates/google_doc.html
@@ -1,4 +1,6 @@
 <div class="row">
+	<div class="span4 offset"><div id="nav-wrap">{{ nav|safe }}</div></div>
+</div>
+<div class="row">
   <div class="span12">{{ content|safe }}</div>
-  <div class="span4">{{ nav|safe }}</div>
 </div>


### PR DESCRIPTION
Got the google_docs view's table of contents displaying at a fixed position even when the page scrolls.
