### PR TITLE
prepend an underscore incase id_string starts with a number

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -60,6 +60,8 @@ def clone_xlsform(request, username):
     try:
         form_owner = request.POST.get('username')
         id_string = request.POST.get('id_string')
+        if len(id_string) > 0 and id_string[0].isdidgit():
+            id_string = '_' + id_string
         xform = XForm.objects.get(user__username=form_owner, \
                                     id_string=id_string)
         path = xform.xls.name


### PR DESCRIPTION
This was noticed when cloning the form "2Scouting POI Survey" uploaded by atasoils. The error "The name '2scouting_poi_cloned' is an invalid xml tag. Names must begin with a letter, colon, or underscore, subsequent characters can include numbers, dashes, and periods." is shown. Hence this should prevent that
