### PR TITLE
Issue #226 - used the Popup's offset option to position the popup properly.

### DIFF
--- a/odk_viewer/static/js/mapview.js
+++ b/odk_viewer/static/js/mapview.js
@@ -30,9 +30,9 @@ function initialize() {
                 var targetMarker = e.target;
                 var popup = new L.Popup({
                     'maxWidth': 500,
+                    'offset': new L.Point(0,-50)
                 });
                 latlng = e.latlng;
-                latlng.lat += 1;
                 popup.setLatLng(latlng);
                 $.get(url).done(function(data){
                     popup.setContent(data);


### PR DESCRIPTION
This positions the popup properly however since the popup is tied to an x/y point on the map, zooming in or out re-positions the marker but NOT the popup. A permanent solution I believe would be to bind the popup to a marker if we can figure out how to optimize markers.
