### PR TITLE
Set center coords to 0.0 if the coords are null

### DIFF
--- a/odk_viewer/static/js/mapview.js
+++ b/odk_viewer/static/js/mapview.js
@@ -1,4 +1,4 @@
-var centerLatLng = new L.LatLng(center.lat, center.lng);
+var centerLatLng = new L.LatLng(!center.lat?0.0:center.lat, !center.lng?0.0:center.lng);
 var defaultZoom = 8;
 var mapId = 'map_canvas';
 var map;


### PR DESCRIPTION
Since the GeoJSON implementation also uses the center lat/lng this fix would still be required
