### PR TITLE
changing logic of support email display to match original intent of #322

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -3,4 +3,8 @@
 <h3>
 	500 Error
 </h3>
+
+
+If you are getting this error while trying to submit a form, please do consider sending an email to support@formhub.org with your xlsform attached.
+Thank you for using formhub.
 {% endblock %}

--- a/templates/message.html
+++ b/templates/message.html
@@ -3,11 +3,6 @@
         <div class="alert alert-block {{ message.type }} fade in">
             <a class="close" href="#" data-dismiss="alert">×</a>
             <p>{{ message.text|safe }}</p>
-            {# the following is specific for error message #}
-            {# handling with a bad xls form submission #}
-            {% ifequal message.type "alert-error" %}
-                <p>Please contact us at <a href="support@formhub.org">support@formhub.org</a> attaching the file your are trying to submit. Thank you!</p>
-            {% endifequal %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
msg on the 500 page (ie, when pyxform is failing badly) as opposed to when user sees proper error message.
