### PR TITLE
Removed signal that saved to mongo before attachments were saved.

### DIFF
--- a/odk_logger/models/__init__.py
+++ b/odk_logger/models/__init__.py
@@ -7,6 +7,7 @@ from .xform import XForm
 from .attachment import Attachment
 from .survey_type import SurveyType
 from odk_logger.xform_instance_parser import InstanceParseError
+from odk_viewer.models import ParsedInstance
 
 
 @transaction.commit_on_success
@@ -38,5 +39,7 @@ def create_instance(username, xml_file, media_files, status=u'submitted_via_web'
         instance = Instance.objects.create(xml=xml, user=user, status=status)
         for f in media_files:
             Attachment.objects.get_or_create(instance=instance, media_file=f)
+        if instance.xform is not None:
+            pi, created = ParsedInstance.objects.get_or_create(instance=instance)
         return instance
     return None

--- a/odk_viewer/models/parsed_instance.py
+++ b/odk_viewer/models/parsed_instance.py
@@ -210,13 +210,3 @@ def _remove_from_mongo(sender, **kwargs):
     xform_instances.remove(instance_id)
 
 pre_delete.connect(_remove_from_mongo, sender=ParsedInstance)
-
-
-def _parse_instance(sender, **kwargs):
-    # When an instance is saved, first delete the parsed_instance
-    # associated with it.
-    instance = kwargs["instance"]
-    if instance.xform is not None:
-        pi, created = ParsedInstance.objects.get_or_create(instance=instance)
-
-post_save.connect(_parse_instance, sender=Instance)


### PR DESCRIPTION
Moved that functionality to create_instance

We do away with this signal(https://github.com/modilabs/formhub/blob/master/odk_viewer/models/parsed_instance.py#L222) as it causes the dict for mongo to be built
before attachments are saved. We cannot also add the signal to attachment
model as on instance may have many attachments and we can only create_dict for
mongo once all attachments have been saved.

fixes #386
fixes #420
