### PR TITLE
No need to install mongodb or JRE on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: python
 python:
   - "2.6"
 before_install:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-  - sudo sh -c "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' >> /etc/apt/sources.list"
-  - sudo apt-get install mongodb-10gen
-  - sudo apt-get install default-jre
+  - sudo service mongodb start
 install:
   - pip install -r requirements.pip --use-mirrors
   - python manage.py syncdb --noinput


### PR DESCRIPTION
All VM images have mongodb (from the 10gen repository) and OpenJDK [7]. A good idea is to only make sure it is started (several services will soon be disabled on boot).
