### PR TITLE
Add Natural Earth II as one of the default basemaps #514

### DIFF
--- a/odk_viewer/static/js/mapview.js
+++ b/odk_viewer/static/js/mapview.js
@@ -77,7 +77,8 @@ function initialize() {
     overlays[hexbinLayerLabel] = hexbinLayerGroup;
     layersControl = new L.Control.Layers({}, overlays);
     map.addControl(layersControl);
-    map.addLayer(markerLayerGroup); //show marker layer by default
+    //show marker layer by default
+    map.addLayer(markerLayerGroup);
 
     // add bing maps layer
     $.each(bingMapTypeLabels, function(type, label) {


### PR DESCRIPTION
I fixed the issue by adding Natural Earth II as default basemap in the array of mapbox maps to use as base layers
