### PR TITLE
Changed email field in form to EmailField instead of CharField.

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -142,7 +142,7 @@ class RegistrationFormUserProfile(RegistrationFormUniqueEmail,
     ]
 
     username = forms.CharField(widget=forms.TextInput(), max_length=30)
-    email = forms.CharField(widget=forms.TextInput(), max_length=50)
+    email = forms.EmailField(widget=forms.TextInput())
 
     legal_usernames_re = re.compile("^\w+$")
 


### PR DESCRIPTION
Seems like User is created and the exception is thrown by send_email from the MTA. It does not fail with the python smtpd DebuggingServer for example.

Does not require a migration as this field in only a proxy
in the form for the Django auth one.
