### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 python:
   - "2.7"
 before_install:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-  - sudo sh -c "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' >> /etc/apt/sources.list"
-  - sudo apt-get install mongodb-10gen
-  - sudo apt-get install default-jre
   - sudo apt-get install gfortran libatlas-base-dev
   - sudo service mongodb start
 install:


### PR DESCRIPTION
I've previously submitted the same change but it was lost in conflict
resolution by @modialabs-bumblebee.

There is no need to add 10gen repository or install mongodb or JDK in
the travis-ci.org CI env. All VM images have mongodb and one JDK.

All you have to do to be future proof is to make sure it is started
(it is currently started on boot but we will change this in the future).
