### PR TITLE
Removed mongodb and jre installs from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,7 @@ language: python
 python:
   - "2.7"
 before_install:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-  - sudo sh -c "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' >> /etc/apt/sources.list"
-  - sudo apt-get install mongodb-10gen
-  - sudo apt-get install default-jre
   - sudo apt-get install gfortran libatlas-base-dev
-  - sudo service mongodb start
 install:
   - pip install numpy --use-mirrors
   - pip install -r requirements.pip --use-mirrors


### PR DESCRIPTION
Travis already runs a version of jre and mongo db 2.x so we don't need to do this installs on travis. Hopfully save us some test time.
