### PR TITLE
602: Unique submission View

### DIFF
--- a/odk_viewer/templates/instance.html
+++ b/odk_viewer/templates/instance.html
@@ -83,6 +83,13 @@ Question.prototype.getLabel = function(language)
           loadData(context, query);
       });
 
+      // #uuid/uuid route
+      this.get('#uuid/:uuid', function(context) {
+          var uuid = this.params['uuid'];
+          var query = '{"_uuid": "' + uuid + '"}';
+          loadData(context, query);
+      });
+
 
       // Delete modal
       this.get('#del/:id', function(context) { with(this) {


### PR DESCRIPTION
#602 Unique Submission View

After investigating the many ways of a being able to link to a particular submission ; decided to make the Instance UI (one by one browse) use UUIDs instead of IDs.
UUID is exposed over JSON and bamboo rest service.
