### PR TITLE
no longer using TOUCHFORMS_URL, use ENKETO_URL

### DIFF
--- a/odk_logger/views.py
+++ b/odk_logger/views.py
@@ -321,7 +321,7 @@ def enter_data(request, username, id_string):
                               id_string=id_string)
     if not has_edit_permission(xform, owner, request, xform.shared):
         return HttpResponseForbidden(_(u'Not shared.'))
-    if not hasattr(settings, 'TOUCHFORMS_URL'):
+    if not hasattr(settings, 'ENKETO_URL'):
         return HttpResponseRedirect(reverse('main.views.show',
                                     kwargs={'username': username,
                                             'id_string': id_string}))


### PR DESCRIPTION
settings.py does not have TOUCHFORMS_URL, hence when a test is run it returned a redirect, since we have switched to enketo, lets use and redirect if it does not exist.
