### PR TITLE
Direct import, pep8 cleanup

### DIFF
--- a/odk_viewer/views.py
+++ b/odk_viewer/views.py
@@ -31,7 +31,6 @@ from odk_viewer.tasks import create_async_export
 from utils.user_auth import has_permission, get_xform_and_perms
 from utils.google import google_export_xls, redirect_uri
 # TODO: using from main.views import api breaks the application, why?
-from main.views import api as mongo_api_view
 from odk_viewer.models import Export
 from utils.export_tools import generate_export, should_create_new_export
 from utils.viewer_tools import export_def_from_filename
@@ -118,7 +117,7 @@ def map_view(request, username, id_string):
     context.jsonform_url = reverse(download_jsonform,
                                    kwargs={"username": username,
                                            "id_string": id_string})
-    context.mongo_api_url = reverse(mongo_api_view,
+    context.mongo_api_url = reverse('mongo_view_api',
                                     kwargs={"username": username,
                                             "id_string": id_string})
     context.mapbox_layer = MetaData.mapbox_layer_upload(xform)
@@ -461,7 +460,7 @@ def data_view(request, username, id_string):
         return HttpResponseForbidden(_(u'Not shared.'))
 
     context = RequestContext(request)
-    context.mongo_api_url = reverse(mongo_api_view,
+    context.mongo_api_url = reverse('mongo_view_api',
                                     kwargs={"username": username,
                                             "id_string": id_string})
     context.jsonform_url = reverse(download_jsonform,

--- a/urls.py
+++ b/urls.py
@@ -42,7 +42,7 @@ urlpatterns = patterns('',
 
     # form specific
     url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)$', 'main.views.show'),
-    url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/api$', 'main.views.api'),
+    url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/api$', 'main.views.api', name='mongo_view_api'),
     url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/public_api$', 'main.views.public_api', name='public_api'),
     url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/delete_api$', 'main.views.delete_data'),
     url(r'^(?P<username>[^/]+)/forms/(?P<id_string>[^/]+)/edit$', 'main.views.edit'),


### PR DESCRIPTION
should minimize the occurrences of the exception below
Traceback (most recent call last):

  File "/home/ubuntu/srv/formhub-ec2/project_env/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)

  File "/home/ubuntu/srv/formhub-ec2/project_env/lib/python2.7/site-packages/newrelic-1.6.0.13/newrelic/api/object_wrapper.py", line 214, in **call**
    self._nr_instance, args, kwargs)

  File "/home/ubuntu/srv/formhub-ec2/project_env/lib/python2.7/site-packages/newrelic-1.6.0.13/newrelic/hooks/framework_django.py", line 462, in wrapper
    return wrapped(_args, *_kwargs)

  File "/home/ubuntu/srv/formhub-ec2/formhub/odk_viewer/views.py", line 468, in data_view
    context.mongo_api_url = reverse(main.views.api,

AttributeError: 'module' object has no attribute 'views'
