### PR TITLE
Fixed #865: 500 error on bamboo link creation

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -914,7 +914,7 @@ def link_to_bamboo(request, username, id_string):
     }
 
     # try to delete the dataset first (in case it exists)
-    if delete_bamboo_dataset(xform):
+    if xform.bamboo_dataset and delete_bamboo_dataset(xform):
         xform.bamboo_dataset = u''
         xform.save()
         audit_log(Actions.BAMBOO_LINK_DELETED, request.user, owner,

--- a/utils/bamboo.py
+++ b/utils/bamboo.py
@@ -4,6 +4,7 @@ import csv
 
 from pybamboo.dataset import Dataset
 from pybamboo.connection import Connection
+from pybamboo.exceptions import ErrorParsingBambooData
 
 from odk_viewer.models import ParsedInstance
 from odk_viewer.pandas_mongo_bridge import (CSVDataFrameBuilder,
@@ -21,9 +22,14 @@ def get_bamboo_url(xform):
 
 
 def delete_bamboo_dataset(xform):
-    dataset = Dataset(connection=Connection(url=get_bamboo_url(xform)),
-                      dataset_id=xform.bamboo_dataset)
-    return dataset.delete()
+    if not xform.bamboo_dataset:
+        return False
+    try:
+        dataset = Dataset(connection=Connection(url=get_bamboo_url(xform)),
+                          dataset_id=xform.bamboo_dataset)
+        return dataset.delete()
+    except ErrorParsingBambooData:
+        return False
 
 
 def get_new_bamboo_dataset(xform, force_last=False):


### PR DESCRIPTION
Fixes #865 

There was two issues:
- view called `delete_bamboo_dataset` even if there's no dataset attached.
- `delete_bamboo_dataset` wasn't safe for inexistant datasets.
