### PR TITLE
bump South version to 0.7.6, allows clean migration for empty mysql dbs

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -13,7 +13,7 @@ PIL==1.1.7
 poster==0.8.1
 pymongo==2.2.1
 pyxform==0.9.9.2
-South==0.7.3
+South==0.7.6
 xlrd==0.8.0
 xlwt==0.7.2
 openpyxl==1.5.8


### PR DESCRIPTION
This fixes #482 a bug that existed in South <0.7.3 but was fixed 0.7.4 version of South. upgrading resolves the issue.
