### PR TITLE
XML <![CDATA[]]> support

### DIFF
--- a/odk_logger/xform_instance_parser.py
+++ b/odk_logger/xform_instance_parser.py
@@ -110,6 +110,11 @@ def _xml_node_to_dict(node, repeats=[]):
         # this is an internal node
         value = {}
         for child in node.childNodes:
+
+            # handle CDATA text section
+            if child.nodeType == child.CDATA_SECTION_NODE:
+                return {child.parentNode.nodeName: child.nodeValue}
+
             d = _xml_node_to_dict(child, repeats)
             if d is None:
                 continue


### PR DESCRIPTION
Incoming XForms are parsed using minidom (SAX) which means the XML must be valid (obviously).

It means that text values in XML nodes (Form data) _can not contain_ reserved characters like -- **& < > ' "** -- (I believe the formers depend on the parser though).

For those characters to be interpreted as content (and accept the XML submission), the text value need to be encapsulated into a <![CDATA[]]> node.

It seems that ODK Collect doesn't do it so it means that there is a high risk that submissions are failing when one of the illegal characters are encountered.
**Note**: we should check that and potentially fill a bug at ODK.

Additionally, formhub doesn't support <![CDATA[]]> so even if the submission was sent properly, all the fields would be blank.

This is what this P.R fixes: it adds support for <![CDATA[]]> in formhub. This is needed.
