### PR TITLE
bump pyxform version to 0.9.11

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -12,7 +12,7 @@ modilabs-python-utils==0.1.5
 PIL==1.1.7
 poster==0.8.1
 pymongo==2.2.1
-pyxform==0.9.10
+pyxform==0.9.11
 South==0.7.6
 xlrd==0.8.0
 xlwt==0.7.2


### PR DESCRIPTION
- required cascade field support
- white spaced bind:relevant fields ignored
