### PR TITLE
Prefix Columns Names on Bamboo link [2]

### DIFF
--- a/restservice/services/bamboo.py
+++ b/restservice/services/bamboo.py
@@ -21,7 +21,8 @@ class ServiceDefinition(RestServiceInterface):
 
         for row in rows:
             for col, value in row.items():
-                if col.startswith('_') or col.startswith('meta_'):
+                if col.startswith('_') or col.startswith('meta_') \
+                    or col.startswith('meta/'):
                     new_col = (u'%(prefix)s%(col)s'
                                % {'prefix': prefix, 'col': col})
                     row.update({new_col: value})

--- a/utils/bamboo.py
+++ b/utils/bamboo.py
@@ -137,7 +137,8 @@ def get_csv_data(xform, force_last=False):
             if is_header:
                 is_header = False
                 for idx, col in enumerate(row):
-                    if col.startswith('_') or col.startswith('meta_'):
+                    if col.startswith('_') or col.startswith('meta_') \
+                        or col.startswith('meta/'):
                         row[idx] = (u'%(prefix)s%(col)s'
                                     % {'prefix': prefix, 'col': col})
             writer.writerow(row)


### PR DESCRIPTION
Missed `meta` fields as they are `meta/` in FH and becomes `meta_` in bamboo.
