### PR TITLE
Fix question names missing on instance view if no language is set

### DIFF
--- a/odk_viewer/templates/instance.html
+++ b/odk_viewer/templates/instance.html
@@ -428,6 +428,9 @@ function parseLanguages(children)
             break;
         }
     }
+    if (languages.length == 0) {
+    	languages.push('en');
+    }
 }
 </script>
 


### PR DESCRIPTION
In the instance view of a form's data, if the form defined no languages, it's frequent (not sure about the cause) that the question names does not appear.

This fixes it by setting a default language if none was auto-detected.
