### PR TITLE
pin elaphe==0.5.3

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -32,7 +32,7 @@ pandas==0.9.1
 
 requests==0.14
 
-elaphe
+elaphe==0.5.3
 
 # devel only
 twill


### PR DESCRIPTION
A fix to the error below, seems elaphe 0.5.5 is broken.

``` python
Downloading/unpacking elaphe (from -r requirements.pip (line 35))
  Downloading elaphe-0.5.5.tar.gz (67kB): 67kB downloaded
  Running setup.py egg_info for package elaphe
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/home/travis/virtualenv/python2.7/build/elaphe/setup.py", line 18, in <module>
        open(pathjoin(dirname(abspath(__file__)), 'LICENSE')).read(),
    IOError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python2.7/build/elaphe/LICENSE'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
  File "<string>", line 16, in <module>
  File "/home/travis/virtualenv/python2.7/build/elaphe/setup.py", line 18, in <module>
    open(pathjoin(dirname(abspath(__file__)), 'LICENSE')).read(),
IOError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python2.7/build/elaphe/LICENSE'
```
