### PR TITLE
Fixed #1136 View By and Export menu not working for non-logged-in users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,9 +21,7 @@
     <!--[if lte IE 8]>
       <link href="//netdna.bootstrapcdn.com/font-awesome/3.0/css/font-awesome-ie7.css" rel="stylesheet">
     <![endif]-->
-	{% if user.is_authenticated %}
 	  <link href="/static/bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet">
-	{% endif %}
 	{% if not user.is_authenticated %}
 		<link href="/static/css/bg.css" rel="stylesheet">
 	{% endif %}


### PR DESCRIPTION
After some searching, it appeared that data was in but it was a z-index problem caused by Bootstap responsive being included only for logged-in users.
I see no reason for not providing it to all.
