### PR TITLE
Fixed #1132 by adding a switch to display or not the values which have 0 data

### DIFF
--- a/odk_viewer/static/js/mapview.js
+++ b/odk_viewer/static/js/mapview.js
@@ -3,8 +3,8 @@ var _rebuildHexLegend__p_str = gettext('Proportion of surveys with response(s): 
 var getBootstrapFields__str = gettext("ERROR: constants not found; please include main/static/js/formManagers.js");
 var JSONSurveyToHTML__q_str = gettext("Question");
 var JSONSurveyToHTML__r_str = gettext("Response");
-var hideZeroedValues_str = gettext("Hide empty (0) Values");
-var displayZeroedValues_str = gettext("Display empty (0) Values");
+var hideZeroedValues_str = gettext("Hide options without data");
+var displayZeroedValues_str = gettext("Display options without data");
 
 // Global toggle on whether to display question values which have 0 submissions
 var displayZeroedValues = false;


### PR DESCRIPTION
I added the switch to the bottom so it's always visible.
Please send feedback on the wording:
- "Hide empty (0) Values"
- "Display empty (0) Values"
  and also on the CSS effect: using an `inactive` look when those are hidden and an `active` look when they are present
