### PR TITLE
Reset Email Template Syntax error.

### DIFF
--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -7,7 +7,7 @@
     Please set a new password by following the link below:
 {% endblocktrans %}
 {% block reset_link %}
-    {{ protocol }}://{{ domain }}{% url "auth_password_reset_confirm" uidb36=uid, token=token %}
+    {{ protocol }}://{{ domain }}{% url "auth_password_reset_confirm" uidb36=uid token=token %}
 {% endblock %}
 
 {% blocktrans %}


### PR DESCRIPTION
Got introduced with upgrade to django 1.5, see `new-style` url tag as explained in https://docs.djangoproject.com/en/dev/releases/1.5/#overview.

Fixes:

``` python
TemplateSyntaxError: Could not parse the remainder: ',' from 'uid,'
```
