### PR TITLE
Shut off the email to admins when a badly-formed excel file is uploaded ...

### DIFF
--- a/utils/logger_tools.py
+++ b/utils/logger_tools.py
@@ -289,12 +289,7 @@ def publish_form(callback):
             'text': _(u'Form validation timeout, please try again.'),
         }
     except Exception, e:
-        # an exception at this point is not a 500 server error,
-        # it is due instead to a badly-formed excel file by a user,
-        # but since that message is sent to the UI for the user to see,
-        # there is no need to send an email to the admins, which is
-        # what the report_exception() is doing
-        #report_exception("ERROR: XLSForm publishing Exception", e)
+        # error in the XLS file; show an error to the user
         return {
             'type': 'alert-error',
             'text': e


### PR DESCRIPTION
...by a user (the user gets a message through the UI, and since it is not a 500 server error, there is no need to report it as one)
