### PR TITLE
Added Nepali (ne), Dutch (nl), and Chinese (zh) to settings.LANGUAGES, u...

### DIFF
--- a/formhub/settings.py
+++ b/formhub/settings.py
@@ -51,6 +51,9 @@ LANGUAGES = (
     ('es', u'Español'),
     ('it', u'Italiano'),
     ('km', u'ភាសាខ្មែរ'),
+    ('ne', u'नेपाली'),
+    ('nl', u'Nederlands'),
+    ('zh', u'中文'),
 )
 
 SITE_ID = 1


### PR DESCRIPTION
...sing the native language names found here: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

All three of these languages had translation contributions merged into the master branch in formhub/formhub/locale but no one had updated settings.py so that they would take effect.
