### PR TITLE
Fixed bug which causes the same QR code and URL to be displayed for all forms.

### DIFF
--- a/static/js/application.js
+++ b/static/js/application.js
@@ -162,6 +162,11 @@ $(document).ready(function(){
     $(".modal form").submit(function(){
         $(this).parent(".modal").modal('hide');
     });
+
+    //Reset mobile modals after close
+    $('#popupmodal').on('hidden', function() {
+        $(this).removeData('modal');
+    });
 });
 
 function setHrefFromSelect(id) {


### PR DESCRIPTION
Hi All, 

The modal form of the 'Mobile' functionality, which displays the QR code, wasn't being properly reset after it was being closed. This caused the same QR code and URL to appear for every subsequent view.

-Adam